### PR TITLE
resolvendo o erro do código fonte relacionado as rotas

### DIFF
--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -19,4 +19,5 @@ const uploadArchive = async (req, res) => {
 
 module.exports = {
   run,
+  uploadArchive 
 };


### PR DESCRIPTION
O problema era a ausência de uma exportação de função. Colocando ela o erro foi corrigido. 

![image](https://github.com/Avapolos-dev/syncer/assets/37845180/ddcbafbb-29f6-4e80-b5db-d8450250679a)
